### PR TITLE
feat(Abstractions): Improve IEntityId<T> flexibility with covariance and encapsulation

### DIFF
--- a/src/EntityAxis.Abstractions/IEntityId.cs
+++ b/src/EntityAxis.Abstractions/IEntityId.cs
@@ -4,10 +4,10 @@
 /// Defines a contract for entities that expose a unique identifier.
 /// </summary>
 /// <typeparam name="TIdentifierType">The type of the unique identifier.</typeparam>
-public interface IEntityId<TIdentifierType>
+public interface IEntityId<out TIdentifierType>
 {
     /// <summary>
     /// The unique identifier for the entity.
     /// </summary>
-    TIdentifierType Id { get; set; }
+    TIdentifierType Id { get; }
 }

--- a/src/EntityAxis.MediatR/Handlers/UpdateEntityHandler.cs
+++ b/src/EntityAxis.MediatR/Handlers/UpdateEntityHandler.cs
@@ -60,8 +60,6 @@ public class UpdateEntityHandler<TModel, TEntity, TKey> : IRequestHandler<Update
             throw new EntityNotFoundException(typeof(TEntity).Name, request.UpdateModel.Id);
         }
 
-        TKey originalId = entity.Id;
-
         try
         {
             _mapper.Map(request.UpdateModel, entity);
@@ -71,9 +69,6 @@ public class UpdateEntityHandler<TModel, TEntity, TKey> : IRequestHandler<Update
             var message = AutoMapperErrorFormatter.Format<TModel, TEntity>(ex);
             throw new InvalidOperationException(message, ex);
         }
-
-        // Ensure ID was not altered during mapping
-        entity.Id = originalId;
 
         await _updateService.UpdateAsync(entity, cancellationToken);
         return entity.Id;


### PR DESCRIPTION
This commit refines the `IEntityId<T>` interface to better align with clean architecture and domain-driven design principles. The interface no longer requires a setter for `Id`, and the identifier type is now declared as `out T` to enable covariance and broader usage scenarios.

### Key Improvements

- ✅ `IEntityId<T>` now declares `T Id { get; }` with no setter
- ✅ Added `out` modifier to `T` to support covariance
- ✅ Enables implementers to use `protected set` or `init` accessors while maintaining compatibility
- ✅ Removed redundant ID overwrite logic from `UpdateEntityHandler` to delegate responsibility to consumer

### Why It Matters

- Encourages proper entity design with immutable identity
- Improves compatibility with domain-driven models and modern C# patterns
- Enables broader use in generic APIs (e.g., passing `IEntityId<Guid>` as `IEntityId<object>`)
- Respects interface design best practices flagged by SonarCloud

> ✍️ Release Note:
> This is a safe and backward-compatible enhancement for all consumers who read entity IDs. Implementers must now manage identity assignment internally or through mappings, which aligns with rich domain modeling best practices.